### PR TITLE
Scaffold KMP feature modules from PRD MVP scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,53 +47,65 @@ platforms: iOS + Android (KMP shared logic per product doc).
 - Data ownership — export/import supported; user owns their data
 - Max expense amount: 999,999,999.99
 
-**Stack (current Android codebase):** Kotlin 2.2 · Fragments + View Binding (migrating to Compose) ·
-Hilt · Room · MVVM · Coroutines + Flow/LiveData · Retrofit · WorkManager · Min SDK 24 / Target SDK 36
+**Stack (current Android codebase):** Kotlin 2.2 · KMP · Jetpack Compose · Min SDK 24 / Target SDK 36
 
-**Stack (product target):** Kotlin Multiplatform shared logic · SwiftUI (iOS) · Jetpack Compose (Android)
+**Stack (product target):** Kotlin Multiplatform shared logic · SwiftUI (iOS) · Jetpack Compose (Android) · Room (Android) · CoreData (iOS)
 
 ---
 
 ## Architecture
 
 ```
-Fragment / Compose screen
+Compose screen / SwiftUI view
     ↓
-ViewModel (@HiltViewModel, LiveData + Flow via arduia/mvvm-core)
+ViewModel (platform UI layer)
     ↓
-Repository interface → RepositoryImpl
+feature:* repository contracts (KMP commonMain)
     ↓
-Room DAO / Retrofit / Preferences / WorkManager
+core:data contracts → platform storage impl (Room / CoreData)
 ```
+
+See `docs/module_structure.md` for the full module map.
 
 ### Module Structure
 
 ```
 ProExpense/
-├── app/                    Main app, UI, DI, data layer
-├── shared/                 com.arduia.core — extensions, Mapper, locale helpers
-├── backup/                 Excel backup engine (JXL)
-├── expense-backup/         Backup schema/metadata
-├── currency-store/         Currency rate storage
-└── week-expense-graph/     Weekly spend graph widget
+├── app/                         Android Compose shell
+├── shared/                      KMP platform utilities
+├── core/
+│   ├── domain/                  Shared domain models (Amount, FinanceRecord, …)
+│   ├── data/                    Repository contracts, Result wrapper
+│   └── storage/                 Local persistence contracts
+├── feature/
+│   ├── logging/                 Quick Manual Logging (MVP)
+│   ├── currency/                Multi-Currency (MVP)
+│   ├── history/                 Record History (MVP)
+│   ├── sharedcost/              Shared Costs (MVP)
+│   ├── auth/                    PIN Auth (MVP)
+│   └── importexport/            Import & Export (MVP)
+└── iosApp/                      SwiftUI shell (future)
 ```
 
 ### Dependency Rules
 
 | Module | Can depend on |
 |--------|---------------|
-| `app` | all library modules |
-| `week-expense-graph` | `shared` |
-| Library modules | no `app`, no other feature modules |
+| `app` | all `core:*`, all `feature:*`, `shared` |
+| `shared` | nothing (project modules) |
+| `core:domain` | `shared` |
+| `core:data` | `core:domain`, `shared` |
+| `core:storage` | `core:domain`, `shared` |
+| `feature:*` | `core:domain`, `core:data`, `shared` |
+| `feature:*` | **must not** depend on other `feature:*` modules |
 
 ### Key Patterns
 
-- **Hilt** for DI — never introduce Koin
-- **Repository pattern** — single data access point per domain
-- **Mapper pattern** — `Mapper<I,O>` in `:shared`; per-feature `*UiModelMapper`
-- **Result wrapper** — sealed `Result<T>` for async outcomes
-- **No UseCase layer** unless explicitly requested — ViewModels call repositories directly
-- **Amount** value object — stored as integer ×100 in Room
+- **KMP feature modules** — one module per MVP use case; business rules in `commonMain`
+- **Repository pattern** — contracts in `core:data` / `feature:*`; implementations in platform source sets
+- **Result wrapper** — sealed `Result<T>` in `core:data` for async outcomes
+- **Amount** value object — stored as integer ×100 (see `core:domain`)
+- **No cross-feature dependencies** — features compose only at the `app` / UI layer
 
 ---
 
@@ -125,8 +137,7 @@ Default flavor for agent work: **devDebug** (`com.arduia.expense.dev`).
 ./gradlew :app:installDevDebug
 ```
 
-**Prerequisites:** `local.properties` (sdk.dir), `api.properties` (main_url). Firebase builds
-may require `google-services.json` locally.
+**Prerequisites:** `local.properties` (sdk.dir)
 
 ---
 
@@ -179,11 +190,10 @@ AGENTS.md  >  docs/finance_tracker_product.md  >  .cursor/rules/*  >  .cursor/co
 ```
 
 **Known conflicts (always follow AGENTS.md):**
-- **DI:** Hilt, not Koin
-- **Architecture:** MVVM + Repository, not strict MVI
-- **UI (current):** Fragments + View Binding; Compose for new v2 screens when migrating
-- **Testing:** MockK/Robolectric/Espresso, not Roborazzi/Paparazzi
-- **Build gate:** `./gradlew :app:testDevDebugUnitTest`, not `runChecks` (does not exist here)
+- **Architecture:** MVVM + Repository in UI layer; KMP feature modules for shared business logic
+- **UI:** Jetpack Compose (Android); SwiftUI (iOS, future)
+- **Testing:** MockK/Robolectric/Espresso for Android UI tests
+- **Build gate:** `./gradlew :app:compileDevDebugKotlin` or `:core:domain:testDebugUnitTest`
 
 ---
 
@@ -193,6 +203,7 @@ AGENTS.md  >  docs/finance_tracker_product.md  >  .cursor/rules/*  >  .cursor/co
 |------|---------|
 | `AGENTS.md` | Master agent instructions (this file) |
 | `docs/finance_tracker_product.md` | Authoritative product vision, MVP scope, roadmap |
+| `docs/module_structure.md` | KMP module map and dependency rules |
 | `AGENTIC_WORKFLOWS_GUIDE.md` | Reference template (OnDeviceLab origin) |
 | `.cursor/rules/` | Scoped agent rules |
 | `.cursor/commands/` | Slash commands |
@@ -200,4 +211,4 @@ AGENTS.md  >  docs/finance_tracker_product.md  >  .cursor/rules/*  >  .cursor/co
 | `.cursor/context/retrospectives.md` | Append-only post-mortem guard log |
 | `app/build.gradle.kts` | App module build config |
 | `gradle/libs.versions.toml` | Version catalog |
-| `app/src/main/res/navigation/main_nav.xml` | Navigation graph |
+| `docs/module_structure.md` | KMP module map |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,13 @@ dependencies {
     implementation(project(":shared"))
     implementation(project(":core:domain"))
     implementation(project(":core:data"))
+    implementation(project(":core:storage"))
+    implementation(project(":feature:logging"))
+    implementation(project(":feature:currency"))
+    implementation(project(":feature:history"))
+    implementation(project(":feature:sharedcost"))
+    implementation(project(":feature:auth"))
+    implementation(project(":feature:importexport"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)

--- a/core/data/src/commonMain/kotlin/com/arduia/expense/data/CategoryRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/arduia/expense/data/CategoryRepository.kt
@@ -1,0 +1,11 @@
+package com.arduia.expense.data
+
+import com.arduia.expense.domain.Category
+
+interface CategoryRepository {
+    suspend fun getAll(): Result<List<Category>>
+
+    suspend fun upsert(category: Category): Result<Unit>
+
+    suspend fun delete(id: String): Result<Unit>
+}

--- a/core/data/src/commonMain/kotlin/com/arduia/expense/data/FinanceRecordRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/arduia/expense/data/FinanceRecordRepository.kt
@@ -1,7 +1,13 @@
 package com.arduia.expense.data
 
-import com.arduia.expense.domain.Amount
+import com.arduia.expense.domain.FinanceRecord
 
 interface FinanceRecordRepository {
-    suspend fun getTotalRecorded(): Amount
+    suspend fun getAll(): Result<List<FinanceRecord>>
+
+    suspend fun getById(id: String): Result<FinanceRecord?>
+
+    suspend fun upsert(record: FinanceRecord): Result<Unit>
+
+    suspend fun delete(id: String): Result<Unit>
 }

--- a/core/data/src/commonMain/kotlin/com/arduia/expense/data/Result.kt
+++ b/core/data/src/commonMain/kotlin/com/arduia/expense/data/Result.kt
@@ -1,0 +1,7 @@
+package com.arduia.expense.data
+
+sealed class Result<out T> {
+    data class Success<T>(val data: T) : Result<T>()
+
+    data class Error(val message: String, val cause: Throwable? = null) : Result<Nothing>()
+}

--- a/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/Category.kt
+++ b/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/Category.kt
@@ -1,0 +1,7 @@
+package com.arduia.expense.domain
+
+data class Category(
+    val id: String,
+    val name: String,
+    val isCustom: Boolean = false,
+)

--- a/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/CurrencyCode.kt
+++ b/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/CurrencyCode.kt
@@ -1,0 +1,9 @@
+package com.arduia.expense.domain
+
+data class CurrencyCode(val code: String) {
+    init {
+        require(code.length == 3 && code.all { it.isUpperCase() }) {
+            "Currency code must be a 3-letter ISO code"
+        }
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/FinanceRecord.kt
+++ b/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/FinanceRecord.kt
@@ -1,0 +1,12 @@
+package com.arduia.expense.domain
+
+data class FinanceRecord(
+    val id: String,
+    val amount: Amount,
+    val currency: CurrencyCode,
+    val homeCurrencyAmount: Amount,
+    val categoryId: String,
+    val type: RecordType,
+    val note: String?,
+    val recordedAtEpochMillis: Long,
+)

--- a/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/Participant.kt
+++ b/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/Participant.kt
@@ -1,0 +1,6 @@
+package com.arduia.expense.domain
+
+data class Participant(
+    val id: String,
+    val name: String,
+)

--- a/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/RecordType.kt
+++ b/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/RecordType.kt
@@ -1,0 +1,6 @@
+package com.arduia.expense.domain
+
+enum class RecordType {
+    EXPENSE,
+    INCOME,
+}

--- a/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/SharedCost.kt
+++ b/core/domain/src/commonMain/kotlin/com/arduia/expense/domain/SharedCost.kt
@@ -1,0 +1,10 @@
+package com.arduia.expense.domain
+
+data class SharedCost(
+    val id: String,
+    val title: String,
+    val totalAmount: Amount,
+    val currency: CurrencyCode,
+    val participants: List<Participant>,
+    val recordedAtEpochMillis: Long,
+)

--- a/core/storage/build.gradle.kts
+++ b/core/storage/build.gradle.kts
@@ -1,0 +1,36 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.storage"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/core/storage/src/commonMain/kotlin/com/arduia/expense/storage/LocalDataStore.kt
+++ b/core/storage/src/commonMain/kotlin/com/arduia/expense/storage/LocalDataStore.kt
@@ -1,0 +1,5 @@
+package com.arduia.expense.storage
+
+interface LocalDataStore {
+    suspend fun isAvailable(): Boolean
+}

--- a/docs/module_structure.md
+++ b/docs/module_structure.md
@@ -1,0 +1,71 @@
+# KMP Module Structure
+
+Authoritative map for the Finance Tracker KMP multi-module project. Aligned with
+`docs/finance_tracker_product.md` MVP scope.
+
+## Layer Overview
+
+```
+app/                         Android Compose shell (UI only)
+shared/                      Platform utilities (expect/actual)
+core/
+├── domain/                  Shared domain models
+├── data/                    Repository contracts, Result wrapper
+└── storage/                 Local persistence contracts (offline-first)
+feature/
+├── logging/                 Quick Manual Logging (MVP)
+├── currency/                Multi-Currency (MVP)
+├── history/                 Record History (MVP)
+├── sharedcost/              Shared Costs (MVP)
+├── auth/                    PIN Auth (MVP)
+└── importexport/            Secure Import & Export (MVP)
+iosApp/                      SwiftUI shell (future)
+```
+
+## Dependency Rules
+
+| Module | May depend on |
+|--------|---------------|
+| `app` | all `core:*`, all `feature:*`, `shared` |
+| `shared` | nothing (project modules) |
+| `core:domain` | `shared` |
+| `core:data` | `core:domain`, `shared` |
+| `core:storage` | `core:domain`, `shared` |
+| `feature:*` | `core:domain`, `core:data`, `shared` (`importexport` also uses `core:storage`) |
+| `feature:*` | **must not** depend on other `feature:*` modules |
+
+## MVP Feature Mapping (PRD)
+
+| PRD Use Case | Module | Key contracts |
+|--------------|--------|---------------|
+| Quick Manual Logging | `:feature:logging` | `LoggingRepository`, `LogRecordInput` |
+| Multi-Currency | `:feature:currency` | `CurrencyRepository`, `CurrencySettings` |
+| Record History | `:feature:history` | `HistoryRepository`, `RecordHistoryFilter` |
+| Shared Costs | `:feature:sharedcost` | `SharedCostRepository`, `SettlementSummary` |
+| Auth Setup (PIN) | `:feature:auth` | `PinAuthRepository` |
+| Secure Import & Export | `:feature:importexport` | `ImportExportRepository`, `ExportFormat` |
+| Local Storage / Offline | `:core:storage` | `LocalDataStore` |
+
+## Shared Domain Models (`core:domain`)
+
+- `Amount` — money stored as integer cents (max 999,999,999.99)
+- `FinanceRecord` — core expense/income entry
+- `Category`, `CurrencyCode`, `Participant`, `SharedCost`
+- `RecordType` — expense vs income
+
+## Post-MVP Features (not scaffolded yet)
+
+Add as new `feature:*` modules when implementing Phase 2:
+
+- `feature:journal` — Financial Journal
+- `feature:eventbudget` — Event Budget
+- `feature:debt` — Debt & Lending Tracker
+- `feature:localization` — Localization experience
+
+## Platform Implementations (upcoming)
+
+| Layer | Android | iOS |
+|-------|---------|-----|
+| Database | Room (`core:storage` androidMain) | CoreData (`iosMain`) |
+| PIN | Keystore (`feature:auth` androidMain) | Keychain (`iosMain`) |
+| UI | Jetpack Compose (`app`) | SwiftUI (`iosApp`) |

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":core:data"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.feature.auth"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/feature/auth/src/commonMain/kotlin/com/arduia/expense/feature/auth/PinAuthRepository.kt
+++ b/feature/auth/src/commonMain/kotlin/com/arduia/expense/feature/auth/PinAuthRepository.kt
@@ -1,0 +1,18 @@
+package com.arduia.expense.feature.auth
+
+import com.arduia.expense.data.Result
+
+data class AuthSession(
+    val isPinEnabled: Boolean,
+    val isUnlocked: Boolean,
+)
+
+interface PinAuthRepository {
+    suspend fun isPinConfigured(): Result<Boolean>
+
+    suspend fun setPin(pin: String): Result<Unit>
+
+    suspend fun verifyPin(pin: String): Result<Boolean>
+
+    suspend fun clearPin(): Result<Unit>
+}

--- a/feature/currency/build.gradle.kts
+++ b/feature/currency/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":core:data"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.feature.currency"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/feature/currency/src/commonMain/kotlin/com/arduia/expense/feature/currency/CurrencyRepository.kt
+++ b/feature/currency/src/commonMain/kotlin/com/arduia/expense/feature/currency/CurrencyRepository.kt
@@ -1,0 +1,26 @@
+package com.arduia.expense.feature.currency
+
+import com.arduia.expense.data.Result
+import com.arduia.expense.domain.Amount
+import com.arduia.expense.domain.CurrencyCode
+
+data class CurrencySettings(
+    val homeCurrency: CurrencyCode,
+)
+
+data class ExchangeRateInput(
+    val from: CurrencyCode,
+    val to: CurrencyCode,
+    val rate: Double,
+)
+
+interface CurrencyRepository {
+    suspend fun getSettings(): Result<CurrencySettings>
+
+    suspend fun setHomeCurrency(currency: CurrencyCode): Result<Unit>
+}
+
+fun convertToHomeCurrency(amount: Amount, exchangeRate: Double): Amount {
+    require(exchangeRate > 0) { "Exchange rate must be positive" }
+    return Amount((amount.valueInCents * exchangeRate).toLong())
+}

--- a/feature/history/build.gradle.kts
+++ b/feature/history/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":core:data"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.feature.history"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/feature/history/src/commonMain/kotlin/com/arduia/expense/feature/history/HistoryRepository.kt
+++ b/feature/history/src/commonMain/kotlin/com/arduia/expense/feature/history/HistoryRepository.kt
@@ -1,0 +1,32 @@
+package com.arduia.expense.feature.history
+
+import com.arduia.expense.data.Result
+import com.arduia.expense.domain.Amount
+import com.arduia.expense.domain.CurrencyCode
+import com.arduia.expense.domain.FinanceRecord
+
+data class RecordHistoryFilter(
+    val categoryId: String? = null,
+    val currency: CurrencyCode? = null,
+    val fromEpochMillis: Long? = null,
+    val toEpochMillis: Long? = null,
+    val query: String? = null,
+)
+
+enum class SummaryPeriod {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+}
+
+data class RecordSummary(
+    val period: SummaryPeriod,
+    val totalInHomeCurrency: Amount,
+    val recordCount: Int,
+)
+
+interface HistoryRepository {
+    suspend fun getRecords(filter: RecordHistoryFilter = RecordHistoryFilter()): Result<List<FinanceRecord>>
+
+    suspend fun getSummary(period: SummaryPeriod, anchorEpochMillis: Long): Result<RecordSummary>
+}

--- a/feature/importexport/build.gradle.kts
+++ b/feature/importexport/build.gradle.kts
@@ -1,0 +1,38 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":core:data"))
+            implementation(project(":core:storage"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.feature.importexport"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/feature/importexport/src/commonMain/kotlin/com/arduia/expense/feature/importexport/ImportExportRepository.kt
+++ b/feature/importexport/src/commonMain/kotlin/com/arduia/expense/feature/importexport/ImportExportRepository.kt
@@ -1,0 +1,22 @@
+package com.arduia.expense.feature.importexport
+
+import com.arduia.expense.data.Result
+import com.arduia.expense.domain.FinanceRecord
+
+enum class ExportFormat {
+    CSV,
+    JSON,
+}
+
+data class ImportSummary(
+    val importedCount: Int,
+    val skippedCount: Int,
+)
+
+interface ImportExportRepository {
+    suspend fun exportAll(format: ExportFormat): Result<String>
+
+    suspend fun importFrom(content: String, format: ExportFormat): Result<ImportSummary>
+
+    suspend fun previewImport(content: String, format: ExportFormat): Result<List<FinanceRecord>>
+}

--- a/feature/logging/build.gradle.kts
+++ b/feature/logging/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":core:data"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.feature.logging"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/feature/logging/src/commonMain/kotlin/com/arduia/expense/feature/logging/LoggingRepository.kt
+++ b/feature/logging/src/commonMain/kotlin/com/arduia/expense/feature/logging/LoggingRepository.kt
@@ -1,0 +1,25 @@
+package com.arduia.expense.feature.logging
+
+import com.arduia.expense.data.Result
+import com.arduia.expense.domain.Amount
+import com.arduia.expense.domain.CurrencyCode
+import com.arduia.expense.domain.FinanceRecord
+import com.arduia.expense.domain.RecordType
+
+data class LogRecordInput(
+    val amount: Amount,
+    val currency: CurrencyCode,
+    val homeCurrencyAmount: Amount,
+    val categoryId: String,
+    val type: RecordType = RecordType.EXPENSE,
+    val note: String? = null,
+    val recordedAtEpochMillis: Long,
+)
+
+interface LoggingRepository {
+    suspend fun createRecord(input: LogRecordInput): Result<FinanceRecord>
+
+    suspend fun updateRecord(record: FinanceRecord): Result<Unit>
+
+    suspend fun deleteRecord(id: String): Result<Unit>
+}

--- a/feature/sharedcost/build.gradle.kts
+++ b/feature/sharedcost/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":core:domain"))
+            implementation(project(":core:data"))
+            implementation(project(":shared"))
+            implementation(libs.coroutines.core)
+        }
+    }
+}
+
+android {
+    namespace = "com.arduia.expense.feature.sharedcost"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}

--- a/feature/sharedcost/src/commonMain/kotlin/com/arduia/expense/feature/sharedcost/SharedCostRepository.kt
+++ b/feature/sharedcost/src/commonMain/kotlin/com/arduia/expense/feature/sharedcost/SharedCostRepository.kt
@@ -1,0 +1,33 @@
+package com.arduia.expense.feature.sharedcost
+
+import com.arduia.expense.data.Result
+import com.arduia.expense.domain.Amount
+import com.arduia.expense.domain.CurrencyCode
+import com.arduia.expense.domain.Participant
+import com.arduia.expense.domain.SharedCost
+
+data class SharedCostInput(
+    val title: String,
+    val totalAmount: Amount,
+    val currency: CurrencyCode,
+    val participants: List<Participant>,
+    val recordedAtEpochMillis: Long,
+)
+
+data class SettlementLine(
+    val participant: Participant,
+    val owedAmount: Amount,
+)
+
+data class SettlementSummary(
+    val sharedCostId: String,
+    val lines: List<SettlementLine>,
+)
+
+interface SharedCostRepository {
+    suspend fun create(input: SharedCostInput): Result<SharedCost>
+
+    suspend fun getAll(): Result<List<SharedCost>>
+
+    suspend fun getSettlement(sharedCostId: String): Result<SettlementSummary>
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,21 @@ dependencyResolutionManagement {
 
 rootProject.name = "ProExpense"
 
+// Android shell
 include(":app")
+
+// KMP platform utilities
 include(":shared")
+
+// Core layers
 include(":core:domain")
 include(":core:data")
+include(":core:storage")
+
+// MVP feature modules (PRD Phase 1)
+include(":feature:logging")
+include(":feature:currency")
+include(":feature:history")
+include(":feature:sharedcost")
+include(":feature:auth")
+include(":feature:importexport")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scaffolds the KMP multi-module project structure from the PRD MVP scope, with one module per use case and clear dependency boundaries.

## Module layout

```
app/                         Android Compose shell
shared/                      Platform utilities
core/
├── domain/                  Amount, FinanceRecord, Category, CurrencyCode, …
├── data/                    Result<T>, FinanceRecordRepository, CategoryRepository
└── storage/                 LocalDataStore (offline-first foundation)
feature/
├── logging/                 Quick Manual Logging
├── currency/                Multi-Currency
├── history/                 Record History
├── sharedcost/              Shared Costs
├── auth/                    PIN Auth
└── importexport/            Import & Export (CSV/JSON)
```

## Key rules

- Feature modules **must not** depend on each other — composition happens in `app`
- Each MVP feature has repository contracts in `commonMain` ready for platform impls
- Post-MVP features (journal, event budget, debt, localization) documented but not scaffolded yet

## Docs

- `docs/module_structure.md` — full module map and PRD mapping
- `AGENTS.md` — updated architecture and dependency rules

## Verification

- `./gradlew :app:compileDevDebugKotlin` ✅
- `./gradlew :core:domain:testDebugUnitTest` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a92d1245-046c-4da7-a0ef-d390f5bb78c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a92d1245-046c-4da7-a0ef-d390f5bb78c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

