### PR TITLE
Keep Reports top bar and month pill fixed while swiping periods

### DIFF
--- a/.cursor/context/project_codebase.md
+++ b/.cursor/context/project_codebase.md
@@ -4,7 +4,7 @@
 > Do not edit by hand — it is overwritten. Authoritative prose lives in `AGENTS.md` and `docs/`.
 
 - **Last updated:** 2026-07-01
-- **Branch:** `claude/v2-migration-branch-setup-pok6n5`
+- **Branch:** `claude/gradle-deps-api-access-3u5yhn`
 - **Stack:** Kotlin Multiplatform · Jetpack Compose (Android) · offline-first
 - **PR base (v2 migration):** PRs target `refactor/v2-migration` until the migration completes — not `main`.
 

--- a/feature/reports/src/androidMain/kotlin/com/arduia/expense/feature/reports/ui/ReportsFlow.kt
+++ b/feature/reports/src/androidMain/kotlin/com/arduia/expense/feature/reports/ui/ReportsFlow.kt
@@ -2,24 +2,37 @@ package com.arduia.expense.feature.reports.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.launch
+import com.arduia.expense.feature.reports.R
 import com.arduia.expense.feature.reports.ui.preview.ReportsUiState
 import com.arduia.expense.feature.reports.ui.preview.previewReports
 import com.arduia.expense.feature.reports.ui.preview.previewReportsEmpty
 import com.arduia.expense.feature.reports.ui.preview.previewReportsUncategorized
+import com.arduia.expense.ui.design.EmptyStateContent
+import com.arduia.expense.ui.design.ProTopBar
 import com.arduia.expense.ui.theme.ProArtboard
 import com.arduia.expense.ui.theme.ProExpenseTheme
 
 /**
- * Reports UI flow. [periods] cycles via period chevrons; [empty] shows new-user state.
+ * Reports UI flow. [periods] cycles via period chevrons or a swipe on the body below the pill.
+ * The top bar and month pill are fixed chrome, hoisted above the pager — only the content
+ * underneath (total, donut, categories) pages between periods, so switching months never reads
+ * like navigating to a new screen.
  */
 @Composable
 fun ReportsFlow(
@@ -31,6 +44,7 @@ fun ReportsFlow(
     onLogFirstExpense: () -> Unit = {},
 ) {
     val colors = ProExpenseTheme.colors
+    val dimens = ProExpenseTheme.dimensions
     val pagerState = rememberPagerState(
         initialPage = initialPage.coerceIn(0, (periods.size - 1).coerceAtLeast(0)),
         pageCount = { periods.size.coerceAtLeast(1) },
@@ -48,30 +62,69 @@ fun ReportsFlow(
         }
     }
 
-    Box(
+    val globalEmpty = empty || periods.isEmpty()
+
+    Column(
         modifier = modifier
             .fillMaxSize()
-            .background(colors.paper),
+            .background(colors.paper)
+            .statusBarsPadding()
+            .navigationBarsPadding(),
     ) {
-        val globalEmpty = empty || periods.isEmpty()
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.fillMaxSize(),
-        ) { page ->
-            ReportsScreen(
-                state = if (globalEmpty) previewReportsEmpty else periods[page % periods.size],
+        Box(modifier = Modifier.padding(horizontal = dimens.screenPadding)) {
+            ProTopBar(
+                title = stringResource(R.string.reports_title),
                 onBack = onBack,
-                onPrevPeriod = {
+                backLabel = stringResource(R.string.reports_back),
+            )
+        }
+
+        if (globalEmpty) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = dimens.screenPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                EmptyStateContent(
+                    title = stringResource(R.string.reports_empty_title),
+                    subtitle = stringResource(R.string.reports_empty_subtitle),
+                    actionLabel = stringResource(R.string.reports_empty_action),
+                    onActionClick = onLogFirstExpense,
+                )
+            }
+            return@Column
+        }
+
+        val currentPeriod = periods[pagerState.currentPage % periods.size]
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dimens.screenPadding)
+                .padding(top = dimens.space8),
+            contentAlignment = Alignment.Center,
+        ) {
+            ReportsPeriodPill(
+                label = currentPeriod.periodLabel,
+                onPrev = {
                     scope.launch {
                         pagerState.animateScrollToPage((pagerState.currentPage - 1 + periods.size) % periods.size.coerceAtLeast(1))
                     }
                 },
-                onNextPeriod = {
+                onNext = {
                     scope.launch {
                         pagerState.animateScrollToPage((pagerState.currentPage + 1) % periods.size.coerceAtLeast(1))
                     }
                 },
-                globalEmpty = globalEmpty,
+            )
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize(),
+        ) { page ->
+            ReportsPeriodContent(
+                state = periods[page % periods.size],
                 onLogFirstExpense = onLogFirstExpense,
             )
         }

--- a/feature/reports/src/androidMain/kotlin/com/arduia/expense/feature/reports/ui/ReportsScreen.kt
+++ b/feature/reports/src/androidMain/kotlin/com/arduia/expense/feature/reports/ui/ReportsScreen.kt
@@ -62,7 +62,6 @@ fun ReportsScreen(
 ) {
     val colors = ProExpenseTheme.colors
     val dimens = ProExpenseTheme.dimensions
-    val typography = ProExpenseTheme.typography
 
     Column(
         modifier = modifier
@@ -101,104 +100,131 @@ fun ReportsScreen(
             return@Column
         }
 
-        Column(
+        // The pill is a fixed header, not part of the swipeable body below — it must stay put
+        // while only the content underneath changes, so switching periods never reads like
+        // navigating to a new screen.
+        Box(
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .fillMaxWidth()
                 .padding(horizontal = dimens.screenPadding)
-                .padding(top = dimens.space8, bottom = dimens.space24),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(dimens.space16),
+                .padding(top = dimens.space8),
+            contentAlignment = Alignment.Center,
         ) {
             ReportsPeriodPill(
                 label = state.periodLabel,
                 onPrev = onPrevPeriod,
                 onNext = onNextPeriod,
             )
+        }
 
-            if (state.empty) {
-                EmptyStateContent(
-                    title = stringResource(R.string.reports_period_empty_title),
-                    subtitle = stringResource(R.string.reports_period_empty_subtitle),
-                    actionLabel = stringResource(R.string.reports_period_empty_action),
-                    onActionClick = onLogFirstExpense,
-                    modifier = Modifier.padding(vertical = dimens.space24),
-                )
-                return@Column
-            }
+        ReportsPeriodContent(
+            state = state,
+            onLogFirstExpense = onLogFirstExpense,
+        )
+    }
+}
 
-            if (!state.uncategorized) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = stringResource(R.string.reports_total_spent),
-                        style = typography.eyebrow,
-                        color = colors.muted,
-                    )
-                    Text(
-                        text = state.totalLabel,
-                        style = typography.displayAmount,
-                        color = colors.onSurface,
-                        modifier = Modifier.padding(top = dimens.space8),
-                    )
-                    Text(
-                        text = buildAnnotatedString {
-                            append(stringResource(R.string.reports_daily_avg_prefix) + " ")
-                            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = colors.onSurface)) {
-                                append(state.dailyAvgLabel)
-                            }
-                            append(" · ${state.daysLabel}")
-                        },
-                        style = typography.caption,
-                        color = colors.onSurfaceMuted,
-                        modifier = Modifier.padding(top = dimens.space6),
-                    )
-                }
-            } else {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = stringResource(R.string.reports_period_total, state.periodLabel),
-                        style = typography.eyebrow,
-                        color = colors.muted,
-                        textAlign = TextAlign.Center,
-                    )
-                    Text(
-                        text = state.totalLabel,
-                        style = typography.summaryAmount,
-                        color = colors.onSurface,
-                        modifier = Modifier.padding(top = dimens.space8),
-                    )
-                }
-            }
+@Composable
+internal fun ReportsPeriodContent(
+    state: ReportsUiState,
+    onLogFirstExpense: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = ProExpenseTheme.colors
+    val dimens = ProExpenseTheme.dimensions
+    val typography = ProExpenseTheme.typography
 
-            ReportsDonut(
-                categories = state.categories,
-                uncategorized = state.uncategorized,
-                modifier = Modifier.padding(vertical = dimens.space8),
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = dimens.screenPadding)
+            .padding(top = dimens.space16, bottom = dimens.space24),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(dimens.space16),
+    ) {
+        if (state.empty) {
+            EmptyStateContent(
+                title = stringResource(R.string.reports_period_empty_title),
+                subtitle = stringResource(R.string.reports_period_empty_subtitle),
+                actionLabel = stringResource(R.string.reports_period_empty_action),
+                onActionClick = onLogFirstExpense,
+                modifier = Modifier.padding(vertical = dimens.space24),
             )
+            return@Column
+        }
 
-            if (state.uncategorized) {
-                ReportsTipBanner()
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(dimens.space10)) {
-                    Text(
-                        text = stringResource(R.string.reports_top_categories),
-                        style = typography.eyebrow,
-                        color = colors.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(ProExpenseTheme.shapes.card)
-                            .border(BorderStroke(1.dp, colors.line), ProExpenseTheme.shapes.card)
-                            .background(colors.surface),
-                    ) {
-                        state.categories.forEachIndexed { index, category ->
-                            if (index > 0) {
-                                Box(Modifier.fillMaxWidth().height(1.dp).background(colors.lineSoft))
-                            }
-                            ReportsRankRow(category = category)
+        if (!state.uncategorized) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = stringResource(R.string.reports_total_spent),
+                    style = typography.eyebrow,
+                    color = colors.muted,
+                )
+                Text(
+                    text = state.totalLabel,
+                    style = typography.displayAmount,
+                    color = colors.onSurface,
+                    modifier = Modifier.padding(top = dimens.space8),
+                )
+                Text(
+                    text = buildAnnotatedString {
+                        append(stringResource(R.string.reports_daily_avg_prefix) + " ")
+                        withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = colors.onSurface)) {
+                            append(state.dailyAvgLabel)
                         }
+                        append(" · ${state.daysLabel}")
+                    },
+                    style = typography.caption,
+                    color = colors.onSurfaceMuted,
+                    modifier = Modifier.padding(top = dimens.space6),
+                )
+            }
+        } else {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = stringResource(R.string.reports_period_total, state.periodLabel),
+                    style = typography.eyebrow,
+                    color = colors.muted,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = state.totalLabel,
+                    style = typography.summaryAmount,
+                    color = colors.onSurface,
+                    modifier = Modifier.padding(top = dimens.space8),
+                )
+            }
+        }
+
+        ReportsDonut(
+            categories = state.categories,
+            uncategorized = state.uncategorized,
+            modifier = Modifier.padding(vertical = dimens.space8),
+        )
+
+        if (state.uncategorized) {
+            ReportsTipBanner()
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(dimens.space10)) {
+                Text(
+                    text = stringResource(R.string.reports_top_categories),
+                    style = typography.eyebrow,
+                    color = colors.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(ProExpenseTheme.shapes.card)
+                        .border(BorderStroke(1.dp, colors.line), ProExpenseTheme.shapes.card)
+                        .background(colors.surface),
+                ) {
+                    state.categories.forEachIndexed { index, category ->
+                        if (index > 0) {
+                            Box(Modifier.fillMaxWidth().height(1.dp).background(colors.lineSoft))
+                        }
+                        ReportsRankRow(category = category)
                     }
                 }
             }
@@ -207,7 +233,7 @@ fun ReportsScreen(
 }
 
 @Composable
-private fun ReportsPeriodPill(
+internal fun ReportsPeriodPill(
     label: String,
     onPrev: () -> Unit,
     onNext: () -> Unit,


### PR DESCRIPTION
## Summary
- Hoist `ProTopBar` and the month pill (`ReportsPeriodPill`) above the `HorizontalPager` in `ReportsFlow` so they render once and stay fixed in place — only the body content (total, donut, category list) pages between months now.
- Extract the swipeable body into a new `ReportsPeriodContent` composable in `ReportsScreen.kt`, reused by both the standalone `ReportsScreen` (Roborazzi tests / UI catalog, public API unchanged) and `ReportsFlow`. Padding/spacing preserved exactly so the standalone screen renders pixel-identical.
- Previously the entire `ReportsScreen` (including the top bar) was a single page inside the pager, so switching months slid the whole screen — chrome included — making it look like a navigation to a new screen instead of an in-place content update.

Stacked on `claude/v2-migration-branch-setup-pok6n5` (#146) since this branch forked from its tip — this diff is scoped to just the 2 new commits on top.

## Test plan
- [x] `./gradlew :app:compileDevDebugKotlin` — clean
- [x] `./gradlew :app:testDevDebugUnitTest --tests "com.arduia.expense.ui.reports.ReportsScreenshotTest"` — green, 0 diffs, run multiple times
- [x] Verified Gradle dependency resolution / outbound network access via proxy (`:app:dependencies`, `buildEnvironment`) — unrelated housekeeping included in this branch
- [ ] Note: full `verifyRoborazziDevDebug` intermittently fails on `EventBudgetScreenshotTest` due to a pre-existing, unrelated stale baseline PNG (shows old "Events" tab title vs current "Budget") — reproducible independent of this change, out of scope here
