### PR TITLE
Sync design-system-spec with Split/Debt row-kind system shipped since…

### DIFF
--- a/design-system-spec/REQUIREMENTS-SYNC-2026-07-11.md
+++ b/design-system-spec/REQUIREMENTS-SYNC-2026-07-11.md
@@ -1,0 +1,72 @@
+# Requirements Sync — 2026-07-11
+
+Follow-up to `REQUIREMENTS-SYNC-2026-07-10.md`. That doc's item 2 ("Shared Costs now count toward
+Journal & Reports") flagged that Journal/Reports mockups would need a visual marker for
+split-originated rows, but didn't yet know the final shape of that system — it shipped over the
+following day's worth of commits (`aaf7653f..3c7f14f7`, ~28 commits). This doc captures the shape
+that landed. Each item below has already been applied to the relevant spec file; this doc is the
+"why," the spec files are the "what."
+
+Scope: genuine product/UX drift only (new or changed intended behavior), same convention as the
+prior sync. Pure bugfixes with no behavior change visible to design (e.g. a deep-link race
+rendering a blank frame, a wrong-tab deep link) are omitted.
+
+## 1. Split and Debt rows are now first-class in Journal (still hidden on Home Recents)
+
+Home Recents and Journal previously rendered every record as a plain Expense/Income row regardless
+of what actually created it. A `RecordKind` classification (Expense / Income / Split / Debt-Lent /
+Debt-Owed) now drives a dedicated badge, title, and tap destination for Split and Debt rows in
+both feeds — but product wants only plain Expense/Income visible on **Home Recents** until this
+mixed-kind UX gets a design pass; **Journal** (the full-history browse) shows every kind now, this
+being genuinely its own screen's purpose. A debt only appears as a real, counted row via its own
+opt-in "record as transaction" toggle — off by default, since a debt is a lending record, not
+necessarily real spending.
+
+**Design ask:** the six-kind row system (Expense/Income/Split/Debt×2) has no Hi-Fi mockup yet —
+worth a dedicated mixed-kind Journal mock, and a decision on whether/when Split rows join Home
+Recents too (engineering already has both feeds working behind a single flag flip).
+
+**Updated:** `screens/03-home.md`, `screens/05-journal.md`, `components/transaction-row.md`.
+
+## 2. Row naming, badge, and amount-color conventions for Split/Debt
+
+Once Split/Debt rows needed to render outside their own feature, three separate conventions had to
+be settled (previously undocumented, iterated live across several commits):
+
+- **Title:** falls back to a type label, never the linked record's bookkeeping category (a debt's
+  linked expense is literally categorized "Shopping" or "Gift," which reads as nonsense in a feed).
+  Split reads **"Split · \<name\>"** (was briefly "Shared - "); Debt reads **"Lent to \<person\>"**
+  / **"Owe \<person\>"**.
+- **Badge:** a fixed glyph + tint per kind instead of a category lookup — Split uses the existing
+  orange @-tag hue, Debt reuses the Debt Tracker's own Lent=green / Owe=red convention regardless
+  of which screen it's rendered on.
+- **Amount color:** follows each screen's own cash-flow convention independently of the badge —
+  neutral ink for Split and Debt-Lent everywhere; Debt-Owed is neutral on Journal but renders
+  success green on Home Recents specifically (the one deliberate screen-specific override).
+
+**Design ask:** confirm the orange badge tint for Split doesn't read as "this is tagged to an
+event" (the @-tag orange is already a taken signal per the 07-10 sync's income-color note) — three
+same-hue usages (event tag, split badge, on-track budget) may need differentiating the same way
+the 07-10 doc flagged for green.
+
+**Updated:** `components/transaction-row.md`, `screens/05-journal.md`, `screens/03-home.md`.
+
+## 3. Event-tagged expenses hide Income categories from the picker
+
+An event budget only makes sense as spend. The category chip row on Add Expense now excludes
+Income categories the instant an expense carries an @ tag to an event — live-checked, so tagging
+via the in-flow "@" picker narrows the choices too, not just the "Add tagged" deep-link entry point
+that starts pre-tagged.
+
+**Design ask:** none blocking — this is a filter rule on the existing category chip layout from the
+07-10 income-support sync, not a new surface.
+
+**Updated:** `screens/07-event-budget.md`.
+
+---
+
+## Not in scope here (see `docs/finance_tracker_product.md` for full MVP status)
+
+Product-level roadmap items unchanged by this sync. Also excluded: pure bugfixes with no design-
+visible behavior change (deep-link race placeholder frame, wrong-tab debt deep link, Shared Cost
+Summary read-only-flag conflation) — tracked in commit history, not design docs.

--- a/design-system-spec/components/transaction-row.md
+++ b/design-system-spec/components/transaction-row.md
@@ -24,10 +24,35 @@ The core list unit. Transactions are grouped under a day header carrying a Inter
 
 - Money uses **Inter**. The event tag is the only warm accent in the row.
 
+## Row kinds (new, previously undocumented)
+
+A row is one of five kinds — Expense, Income, Shared Cost **Split**, Debt **Lent**, Debt **Owed** —
+carried independently of the underlying category (a Split/Debt row still has a category for
+filter/report bucketing, it just never drives the badge). Split and Debt rows appear in Journal;
+Home Recents currently hides Split rows (see `../screens/03-home.md`).
+
+| Kind | Badge glyph | Badge tint | Title | Subtitle type word | Amount color |
+|---|---|---|---|---|---|
+| Expense | category icon | category color | note (or category fallback) | category | `ink` (neutral) |
+| Income | category icon | category color | note (or category fallback) | category | `success` green |
+| Split | fixed "split" glyph | `tag`/`tagTint` (orange) | "Split · \<name\>" or "Shared split" | "Shared split" | `ink` (neutral) |
+| Debt — Lent | fixed "debt" glyph | `success`/`successTint` (green) | "Lent to \<person\>" | "Lent" | `ink` (neutral) |
+| Debt — Owed | fixed "debt" glyph | `danger`/`dangerTint` (red) | "Owe \<person\>" | "Owe" | `ink` neutral by default; `success` green **only** on Home Recents |
+
+- The badge color and the amount color are independent signals — a Debt row's badge always follows
+  the Debt Tracker's own Lent=green/Owe=red convention (`../screens/09-debt-tracker.md`)
+  regardless of screen, while the amount follows each screen's cash-flow convention (see the
+  `emphasizeOwedAsIncome` caller override, Home-only).
+- Tapping a Split or Debt row navigates to that feature's own detail screen (Shared Costs Summary /
+  Debt Detail) instead of the generic edit sheet that Expense/Income rows open.
+
 ## Behavior
-- **Tap a row** to open its edit bottom sheet.
-- **Note fallback:** when `note` is empty the row shows the category label instead; long notes truncate with ellipsis on one line.
-- **Meta line** reads `category · time`, appending the orange event tag only when the txn is linked to an event.
+- **Tap a row** to open its edit bottom sheet (Expense/Income) or the linked feature's detail
+  screen (Split/Debt — see Row kinds above).
+- **Note fallback:** when `note` is empty the row shows the category label instead (or the kind's
+  own type word for Split/Debt — see Row kinds); long notes truncate with ellipsis on one line.
+- **Meta line** reads `category · time` for Expense/Income, or `<type word> · time` for Split/Debt,
+  appending the orange event tag only when the txn is linked to an event.
 - **New row:** a freshly committed expense is inserted at the top and animates with a `clayTint → transparent` highlight pulse over **1800ms** (then clears).
 - The day header is a plain group label (not sticky); the running total reflects only that day's rows.
 

--- a/design-system-spec/screens/03-home.md
+++ b/design-system-spec/screens/03-home.md
@@ -29,6 +29,15 @@
 - With multiple overlapping active events, the header shows the most recently created one.
 - Active Event card appears only when an event is running.
 - Recent transactions: last 5–10 entries (badge, note, meta, amount). “See all” → Journal. Income entries render their amount in success green instead of ink (see `04-add-expense.md` / `components/category.md`).
+- **Row kinds (new, previously undocumented):** a row can be Expense, Income, a Debt (Lent/Owed), or
+  a Shared Cost split — see `components/transaction-row.md` for the shared badge/color/title rules.
+  On Home Recents specifically: Debt Lent/Owed rows are always shown here (a debt is a real,
+  counted transaction the moment its "record as transaction" toggle is on), but Split rows are
+  currently **hidden** from Home Recents pending final mixed-kind UX sign-off — they still show in
+  Journal (see `05-journal.md`). Home Recents is also the one place an **Owe** row's amount renders
+  in success green instead of the neutral tone Journal uses, matching the persona snapshot's
+  optimistic framing; the badge icon color (Lent=green / Owe=red) is unaffected and always follows
+  Debt Tracker's own convention.
 - Empty state (fresh user): illustrated, “No expenses yet…”, single CTA “Log your first expense”.
 - Quick-access tiles deep-link to Reports / Debt / Split / **Goals** (renamed from “Events” — see `components/quick-access.md`).
 - Bottom nav (Home active) + raised center Add are always present on top-level screens.

--- a/design-system-spec/screens/05-journal.md
+++ b/design-system-spec/screens/05-journal.md
@@ -19,6 +19,17 @@
 - When search is active the list flattens (no day grouping); rows show amount, category, date, note.
 - Tap an entry → Journal Detail. Long-press an entry → Quick-note bottom sheet (type + save without leaving the list).
 - Category filter mirrors the category catalogue; “All” default.
+- **Mixed row kinds (new, previously undocumented):** Journal is the full history browse, so —
+  unlike Home Recents — every kind renders here: Expense, Income, Shared Cost splits, and Debt
+  Lent/Owed. A Split or Debt row swaps its badge for a fixed kind icon (not the linked record's
+  bookkeeping category) and its title for a type-specific label instead of the category fallback:
+  a split reads **"Split · \<name\>"** (or "Shared split" when unnamed), a debt reads **"Lent to
+  \<person\>"** / **"Owe \<person\>"**, with the subtitle's leading word matching ("Shared split",
+  "Lent", "Owe"). Amount color follows the same cash-flow convention as Expense/Income for both —
+  Split and Debt-Lent render in the neutral ink tone, Debt-Owed also renders neutral here (Home
+  Recents is the one screen that emphasizes Owe in success green — see `03-home.md`). Tapping a
+  Split or Debt row navigates to that feature's own detail (Shared Costs Summary / Debt Detail)
+  instead of the generic edit sheet. Full rules: `components/transaction-row.md`.
 
 ## Component composition · M3 mapping
 

--- a/design-system-spec/screens/07-event-budget.md
+++ b/design-system-spec/screens/07-event-budget.md
@@ -30,6 +30,12 @@
 - Each card: name, date range, live remaining balance, mini progress bar (budget color system).
 - Over-budget cards show the bar in red + “Over budget” chip.
 - Tap a card → Event Detail. Expenses link via @ tag in Add Expense; balances update in real time.
+- **Category picker is expense-only when tagged to an event (new, previously undocumented):** an
+  event budget only makes sense as spend, so the Add Expense category chip row hides Income
+  categories the moment an expense carries an @ tag to an event — checked live, so switching the
+  tag on/off via the in-flow "@" picker narrows/restores the choices too, not just the "Add
+  tagged" deep-link entry point that starts pre-tagged. See `04-add-expense.md` for the base
+  category chip layout.
 
 ## Component composition · M3 mapping
 


### PR DESCRIPTION
… 2026-07-10

Journal/Home Recents mixed-kind rendering, row naming/badge/color conventions, and the event-tagged income-category filter all landed as real product behavior after the last sync doc but were never reflected back into the Hi-Fi spec docs.